### PR TITLE
Prevent new title showing as old title in browser history

### DIFF
--- a/flow-router-title.js
+++ b/flow-router-title.js
@@ -64,7 +64,9 @@ export class FlowRouterTitle {
         if (!hardCodedTitle) {
           hardCodedTitle = document.title;
         }
-        document.title = newValue;
+        setTimeout(() => {
+          document.title = newValue;
+        }, 0);
         this.curValue = newValue;
       }
     };


### PR DESCRIPTION
Hey, thanks for all the great work on these packages.

## The issue I'm experiencing:
It seems that when changing the page title at the route level, the title updates before the old route is pushed to the browser's history.

E.g.
```js
FlowRouter.route('/', {
   name: 'index',
   title(params, query, data) {
      return 'Home Page'
   }
});
FlowRouter.route('/page-2', {
   name: 'page-2',
   title(params, query, data) {
      return 'Page 2'
   }
});
```

Upon navigating to the site's index the browser's history will be like so:
![Flow-router-title-1](https://user-images.githubusercontent.com/8485492/54578950-2f6b2900-4a4d-11e9-879f-853cc3d2bedb.png)
All is well. However after navigating to Page 2, the history will be:
![Flow-router-title-2](https://user-images.githubusercontent.com/8485492/54579002-56c1f600-4a4d-11e9-86d7-02916726cb7c.png)

This is the issue. `Page 2` should be `Home Page`. Navigating back will correctly take you to the home page, it's just the title in the history is incorrect.

This PR resolves the issue by adding a 0ms timeout to the setting of `document.title`.

Cheers,
Morgan