### PR TITLE
Possible fix #12

### DIFF
--- a/flow-router-title.js
+++ b/flow-router-title.js
@@ -73,7 +73,6 @@ export class FlowRouterTitle {
 
     const computations = [];
     this._reactivate = (titleFunc, _context, context, _arguments, cb) => {
-      const comp = Tracker.autorun(titleFunc.bind(_context, ..._arguments));
       const compute = () => {
         let result = titleFunc.apply(_context, _arguments);
         if (cb) {
@@ -87,8 +86,9 @@ export class FlowRouterTitle {
           }
         }
       };
-      comp.onInvalidate(compute);
-      compute();
+
+      const comp = Tracker.autorun(compute);
+
       computations.push(comp);
     };
 


### PR DESCRIPTION
I tried to fix issue https://github.com/VeliovGroup/Meteor-flow-router-title/issues/12

The problem is the computation was run only once.

From docs: https://docs.meteor.com/api/tracker.html#Tracker-Computation-onInvalidate

> onInvalidate registers a one-time callback that either fires immediately or as soon as the computation is next invalidated or stopped. It is used by reactive data sources to clean up resources or break dependencies when a computation is rerun or stopped.

The advice from MDG is

> To get a callback after a computation has been recomputed, you can call Tracker.afterFlush from onInvalidate.

But I fixed it another way, it should work properly.
